### PR TITLE
Add Wikipedia powered celebrity search

### DIFF
--- a/src/app/[locale]/faces/celebrity/components/CelebritySearchSection.tsx
+++ b/src/app/[locale]/faces/celebrity/components/CelebritySearchSection.tsx
@@ -4,7 +4,7 @@ import { Search } from "lucide-react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 
 import { usePlayerStore } from "@/entities/Player";
 import { FaceCoordinates, ImageMetadata, useImageSelectorStore } from "@/features/ImageSelector/models";
@@ -14,6 +14,7 @@ import { useToastStore } from "@/shared/ui/Toast/stores";
 
 import { useFaceDetection } from "../../hooks/useFaceDetection";
 import { CELEBRITY_PROFILES, CelebrityProfile } from "../configs/sampleCelebrities";
+import { useCelebritySearch } from "../hooks/useCelebritySearch";
 
 const normalizeText = (text: string) =>
   text
@@ -56,6 +57,7 @@ const CelebritySearchSection = () => {
   const { setLoading } = useLoadingStore();
   const { addToast } = useToastStore();
   const { detectFaces, faceCropModel } = useFaceDetection();
+  const { results: searchResults, searchCelebrities, isSearching, clearResults } = useCelebritySearch();
 
   const normalizedQuery = useMemo(() => normalizeText(query), [query]);
 
@@ -69,6 +71,24 @@ const CelebritySearchSection = () => {
       return normalizedName.includes(normalizedQuery) || normalizedTags.some((tag) => tag.includes(normalizedQuery));
     });
   }, [normalizedQuery]);
+
+  useEffect(() => {
+    if (!query.trim()) {
+      clearResults();
+      return;
+    }
+
+    const handler = setTimeout(() => {
+      searchCelebrities(query);
+    }, 400);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [query, searchCelebrities, clearResults]);
+
+  const shouldShowSearchResults = Boolean(normalizedQuery) && searchResults.length > 0;
+  const displayCelebrities = shouldShowSearchResults ? searchResults : filteredCelebrities;
 
   const handleAddCelebrity = async (profile: CelebrityProfile) => {
     if (!faceCropModel) return;
@@ -120,11 +140,13 @@ const CelebritySearchSection = () => {
         <Search className="absolute left-4 top-1/2 -translate-y-1/2" aria-hidden width={18} height={18} />
       </Input>
 
-      {filteredCelebrities.length === 0 ? (
+      {isSearching ? (
+        <p className="body-2 text-text-03">Loading...</p>
+      ) : displayCelebrities.length === 0 ? (
         <p className="body-2 text-text-03">{t("SEARCH_EMPTY", { query })}</p>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          {filteredCelebrities.map((profile) => (
+          {displayCelebrities.map((profile) => (
             <article
               key={profile.id}
               id={profile.id}
@@ -138,6 +160,7 @@ const CelebritySearchSection = () => {
                   className="object-cover"
                   sizes="(max-width: 768px) 100vw, 50vw"
                   priority={false}
+                  unoptimized
                 />
               </div>
 

--- a/src/app/[locale]/faces/celebrity/hooks/useCelebritySearch.ts
+++ b/src/app/[locale]/faces/celebrity/hooks/useCelebritySearch.ts
@@ -1,0 +1,120 @@
+import { useCallback, useRef, useState } from "react";
+
+import { CelebrityProfile } from "../configs/sampleCelebrities";
+
+interface WikipediaPage {
+  pageid: number;
+  title: string;
+  thumbnail?: {
+    source: string;
+  };
+  description?: string;
+}
+
+const WIKIPEDIA_API_ENDPOINT = "https://en.wikipedia.org/w/api.php";
+
+const buildTagsFromDescription = (description?: string): string[] => {
+  if (!description) return [];
+
+  return description
+    .split(/[,/]/)
+    .map((tag) => tag.trim())
+    .filter(Boolean)
+    .slice(0, 4);
+};
+
+export const useCelebritySearch = () => {
+  const [results, setResults] = useState<CelebrityProfile[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const clearResults = useCallback(() => {
+    abortControllerRef.current?.abort();
+    setResults([]);
+    setIsSearching(false);
+  }, []);
+
+  const searchCelebrities = useCallback(
+    async (query: string) => {
+      const trimmedQuery = query.trim();
+
+      if (!trimmedQuery) {
+        clearResults();
+        return [];
+      }
+
+      abortControllerRef.current?.abort();
+
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+
+      setIsSearching(true);
+
+      const params = new URLSearchParams({
+        action: "query",
+        format: "json",
+        prop: "pageimages|description",
+        piprop: "thumbnail",
+        pithumbsize: "640",
+        generator: "search",
+        gsrlimit: "12",
+        gsrsearch: `${trimmedQuery} celebrity`,
+        origin: "*",
+      });
+
+      try {
+        const response = await fetch(`${WIKIPEDIA_API_ENDPOINT}?${params.toString()}`, {
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          throw new Error("Failed to fetch celebrity data");
+        }
+
+        const data = await response.json();
+        const pages: Record<string, WikipediaPage> | undefined = data?.query?.pages;
+
+        if (!pages) {
+          setResults([]);
+          return [];
+        }
+
+        const parsedResults = Object.values(pages)
+          .filter((page) => Boolean(page.thumbnail?.source))
+          .map((page) => ({
+            id: String(page.pageid),
+            name: page.title,
+            imageUrl: page.thumbnail!.source,
+            tags: buildTagsFromDescription(page.description),
+          }));
+
+        setResults(parsedResults);
+
+        return parsedResults;
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") {
+          return [];
+        }
+
+        console.error(error);
+        setResults([]);
+
+        return [];
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsSearching(false);
+        }
+      }
+    },
+    [clearResults],
+  );
+
+  return {
+    results,
+    searchCelebrities,
+    isSearching,
+    clearResults,
+  };
+};
+
+export type UseCelebritySearchReturn = ReturnType<typeof useCelebritySearch>;


### PR DESCRIPTION
## Summary
- add a client-side hook that queries the Wikipedia API for celebrity thumbnails and metadata
- update the celebrity faces search section to use live results with a loading state and fallback to curated presets

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68de906b2324832e93f67969ce833882