### PR TITLE
Add offline-first demo page and API

### DIFF
--- a/public/offline-demo-sw.js
+++ b/public/offline-demo-sw.js
@@ -1,0 +1,154 @@
+const DB_NAME = "offline-demo-db";
+const STORE_NAME = "outbox";
+const DB_VERSION = 1;
+const SYNC_TAG = "offline-demo-sync";
+
+const openDatabase = () =>
+  new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: "id" });
+      }
+    };
+
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+
+const getAllItems = async () => {
+  const db = await openDatabase();
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, "readonly");
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.getAll();
+
+    request.onsuccess = () => resolve(request.result ?? []);
+    request.onerror = () => reject(request.error);
+  });
+};
+
+const updateStatus = async (id, status, error) => {
+  const db = await openDatabase();
+  await new Promise((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, "readwrite");
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.get(id);
+
+    request.onsuccess = () => {
+      const existing = request.result;
+      if (!existing) {
+        resolve();
+        return;
+      }
+
+      store.put({ ...existing, status, error });
+      transaction.oncomplete = () => resolve();
+    };
+
+    request.onerror = () => reject(request.error);
+    transaction.onerror = () => reject(transaction.error);
+  });
+};
+
+const broadcastMessage = async (payload) => {
+  const clientList = await self.clients.matchAll({ type: "window", includeUncontrolled: true });
+  clientList.forEach((client) => client.postMessage(payload));
+};
+
+const broadcastQueue = async () => {
+  const queue = await getAllItems();
+  await broadcastMessage({ type: "outbox-queue", queue });
+};
+
+const fetchQueueItems = async () => {
+  const queue = await getAllItems();
+  return queue.filter((item) => item.status !== "sent");
+};
+
+const flushOutbox = async () => {
+  const pending = await fetchQueueItems();
+
+  if (!pending.length) {
+    await broadcastQueue();
+    await broadcastMessage({ type: "sync-complete" });
+    return;
+  }
+
+  await broadcastMessage({ type: "sync-start" });
+
+  for (const item of pending) {
+    await updateStatus(item.id, "sending");
+    try {
+      const response = await fetch("/api/offline-demo", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: item.id, message: item.content, createdAt: item.createdAt }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`API returned ${response.status}`);
+      }
+
+      await updateStatus(item.id, "sent");
+    } catch (error) {
+      await updateStatus(item.id, "failed", error?.message ?? "Unknown error");
+    }
+  }
+
+  await broadcastQueue();
+  await broadcastMessage({ type: "sync-complete" });
+};
+
+const registerBackgroundSync = async () => {
+  try {
+    const registration = await self.registration.sync.register(SYNC_TAG);
+    return registration;
+  } catch (error) {
+    return null;
+  }
+};
+
+self.addEventListener("install", () => {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener("sync", (event) => {
+  if (event.tag === SYNC_TAG) {
+    event.waitUntil(flushOutbox());
+  }
+});
+
+self.addEventListener("message", (event) => {
+  const data = event.data || {};
+
+  if (data.type === "request-queue") {
+    event.waitUntil(broadcastQueue());
+    return;
+  }
+
+  if (data.type === "manual-sync") {
+    event.waitUntil((async () => {
+      const registration = await registerBackgroundSync();
+      if (!registration) {
+        await flushOutbox();
+      }
+    })());
+    return;
+  }
+
+  if (data.type === "network-status" && data.online) {
+    event.waitUntil((async () => {
+      const registration = await registerBackgroundSync();
+      if (!registration) {
+        await flushOutbox();
+      }
+    })());
+  }
+});

--- a/src/app/[locale]/offline-demo/OfflineDemo.tsx
+++ b/src/app/[locale]/offline-demo/OfflineDemo.tsx
@@ -77,10 +77,10 @@ const OfflineDemo = () => {
   }, [queue]);
 
   useEffect(() => {
-    if (isOnline && queue.some((item) => item.status === "queued" || item.status === "failed")) {
+    if (isOnline && !isFlushing && queue.some((item) => item.status === "queued" || item.status === "failed")) {
       void flushQueue();
     }
-  }, [isOnline]);
+  }, [isOnline, isFlushing, queue]);
 
   const hasPending = useMemo(() => queue.some((item) => item.status === "queued" || item.status === "failed"), [queue]);
 

--- a/src/app/[locale]/offline-demo/OfflineDemo.tsx
+++ b/src/app/[locale]/offline-demo/OfflineDemo.tsx
@@ -1,47 +1,11 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { ButtonLink } from "@/entities/Router";
 import { PAGE_ROUTE } from "@/entities/Router/configs/route";
 
-const STORAGE_KEY = "offline-demo-outbox";
-
-type OutboxItem = {
-  id: string;
-  content: string;
-  createdAt: number;
-  status: "queued" | "sending" | "sent" | "failed";
-  error?: string;
-};
-
-const safeParseQueue = (): OutboxItem[] => {
-  if (typeof window === "undefined") {
-    return [];
-  }
-
-  const raw = window.localStorage.getItem(STORAGE_KEY);
-
-  if (!raw) {
-    return [];
-  }
-
-  try {
-    const parsed = JSON.parse(raw) as OutboxItem[];
-    return Array.isArray(parsed) ? parsed : [];
-  } catch (error) {
-    console.error("Failed to parse outbox", error);
-    return [];
-  }
-};
-
-const persistQueue = (queue: OutboxItem[]) => {
-  if (typeof window === "undefined") {
-    return;
-  }
-
-  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(queue));
-};
+import { getAllOutboxItems, OutboxItem, putOutboxItem } from "./outboxStorage";
 
 const createItem = (content: string): OutboxItem => ({
   id: crypto.randomUUID?.() ?? `outbox-${Date.now()}`,
@@ -50,18 +14,88 @@ const createItem = (content: string): OutboxItem => ({
   status: "queued",
 });
 
+type ServiceWorkerMessage =
+  | { type: "outbox-queue"; queue: OutboxItem[] }
+  | { type: "sync-start" }
+  | { type: "sync-complete" };
+
 const OfflineDemo = () => {
   const [message, setMessage] = useState("");
   const [queue, setQueue] = useState<OutboxItem[]>([]);
   const [isOnline, setIsOnline] = useState(true);
   const [isFlushing, setIsFlushing] = useState(false);
+  const [serviceWorkerReady, setServiceWorkerReady] = useState(false);
+  const swRegistrationRef = useRef<ServiceWorkerRegistration | null>(null);
+
+  const loadQueue = async () => {
+    if (typeof window === "undefined") return;
+    const items = await getAllOutboxItems();
+    setQueue(items);
+  };
+
+  const sendToServiceWorker = (payload: Record<string, unknown>) => {
+    const activeWorker = swRegistrationRef.current?.active ?? navigator.serviceWorker.controller;
+    activeWorker?.postMessage(payload);
+  };
 
   useEffect(() => {
     setIsOnline(navigator.onLine);
-    setQueue(safeParseQueue());
+    void loadQueue();
 
-    const handleOnline = () => setIsOnline(true);
-    const handleOffline = () => setIsOnline(false);
+    if ("serviceWorker" in navigator) {
+      const handleMessage = (event: MessageEvent<ServiceWorkerMessage>) => {
+        if (!event.data) return;
+
+        if (event.data.type === "outbox-queue") {
+          setQueue(event.data.queue);
+          return;
+        }
+
+        if (event.data.type === "sync-start") {
+          setIsFlushing(true);
+          return;
+        }
+
+        if (event.data.type === "sync-complete") {
+          setIsFlushing(false);
+          void loadQueue();
+        }
+      };
+
+      navigator.serviceWorker.addEventListener("message", handleMessage);
+
+      void (async () => {
+        try {
+          const registration = await navigator.serviceWorker.register("/offline-demo-sw.js");
+          const ready = await navigator.serviceWorker.ready;
+          swRegistrationRef.current = ready;
+          setServiceWorkerReady(true);
+          const worker = ready.active ?? registration.active;
+          worker?.postMessage({ type: "request-queue" });
+          worker?.postMessage({ type: "network-status", online: navigator.onLine });
+        } catch (error) {
+          console.error("Service worker registration failed", error);
+        }
+      })();
+
+      return () => {
+        navigator.serviceWorker.removeEventListener("message", handleMessage);
+      };
+    }
+
+    return undefined;
+  }, []);
+
+  useEffect(() => {
+    const handleOnline = () => {
+      setIsOnline(true);
+      sendToServiceWorker({ type: "network-status", online: true });
+      sendToServiceWorker({ type: "manual-sync" });
+    };
+    const handleOffline = () => {
+      setIsOnline(false);
+      sendToServiceWorker({ type: "network-status", online: false });
+    };
 
     window.addEventListener("online", handleOnline);
     window.addEventListener("offline", handleOffline);
@@ -72,82 +106,32 @@ const OfflineDemo = () => {
     };
   }, []);
 
-  useEffect(() => {
-    persistQueue(queue);
-  }, [queue]);
+  const hasPending = useMemo(
+    () => queue.some((item) => item.status === "queued" || item.status === "failed"),
+    [queue],
+  );
 
-  useEffect(() => {
-    if (isOnline && !isFlushing && queue.some((item) => item.status === "queued" || item.status === "failed")) {
-      void flushQueue();
-    }
-  }, [isOnline, isFlushing, queue]);
-
-  const hasPending = useMemo(() => queue.some((item) => item.status === "queued" || item.status === "failed"), [queue]);
-
-  const addMessage = () => {
+  const addMessage = async () => {
     const trimmed = message.trim();
 
     if (!trimmed) {
       return;
     }
 
-    setQueue((prev) => [...prev, createItem(trimmed)]);
+    const item = createItem(trimmed);
+    await putOutboxItem(item);
     setMessage("");
-  };
+    await loadQueue();
 
-  const updateStatus = (id: string, status: OutboxItem["status"], error?: string) => {
-    setQueue((prev) =>
-      prev.map((item) =>
-        item.id === id
-          ? {
-              ...item,
-              status,
-              error,
-            }
-          : item,
-      ),
-    );
-  };
-
-  const flushQueue = async () => {
-    if (isFlushing) {
-      return;
+    if (isOnline && serviceWorkerReady) {
+      sendToServiceWorker({ type: "manual-sync" });
     }
+  };
 
+  const requestFlush = () => {
+    if (!hasPending) return;
     setIsFlushing(true);
-
-    for (const item of queue) {
-      if (item.status === "sent") {
-        continue;
-      }
-
-      updateStatus(item.id, "sending");
-
-      try {
-        const response = await fetch("/api/offline-demo", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            id: item.id,
-            message: item.content,
-            createdAt: item.createdAt,
-          }),
-        });
-
-        if (!response.ok) {
-          throw new Error(`API returned ${response.status}`);
-        }
-
-        updateStatus(item.id, "sent");
-      } catch (error) {
-        console.error("Failed to flush", error);
-        updateStatus(item.id, "failed", error instanceof Error ? error.message : "Unknown error");
-      }
-    }
-
-    setIsFlushing(false);
+    sendToServiceWorker({ type: "manual-sync" });
   };
 
   return (
@@ -165,8 +149,8 @@ const OfflineDemo = () => {
         </div>
 
         <p className="body-2 text-text-02">
-          입력한 메시지는 Outbox (로컬 영속 큐)에 저장됩니다. 오프라인이어도 큐에 기록되며, 온라인 상태가 되면 자동으로 Next API
-          route로 전송되어 서버 콘솔에 기록됩니다.
+          입력한 메시지는 IndexedDB 기반 Outbox (로컬 영속 큐)에 저장됩니다. 오프라인이어도 큐에 기록되며, 서비스 워커가 Background Sync
+          로 온라인 복구 시 큐를 Next API route로 전송하여 서버 콘솔에 기록합니다.
         </p>
       </div>
 
@@ -184,15 +168,15 @@ const OfflineDemo = () => {
         <div className="flex items-center justify-end gap-3">
           <button
             type="button"
-            onClick={addMessage}
+            onClick={() => void addMessage()}
             className="rounded-lg bg-text-01 px-4 py-2 text-background-01 transition hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-40"
-            disabled={!message.trim()}
+            disabled={!message.trim() || !serviceWorkerReady}
           >
             Outbox에 추가
           </button>
           <button
             type="button"
-            onClick={() => void flushQueue()}
+            onClick={requestFlush}
             className="rounded-lg border border-text-01 px-4 py-2 text-text-01 transition hover:bg-text-01 hover:text-background-01 disabled:cursor-not-allowed disabled:opacity-40"
             disabled={!hasPending || isFlushing}
           >
@@ -204,7 +188,7 @@ const OfflineDemo = () => {
       <div className="flex w-full max-w-3xl flex-col gap-3 rounded-xl border border-border-02 bg-background-op-02 p-6 shadow-md">
         <div className="flex items-center justify-between">
           <p className="body-1 font-semibold">Outbox</p>
-          <p className="caption-1 text-text-03">자동 저장 및 재전송</p>
+          <p className="caption-1 text-text-03">자동 저장 및 Background Sync</p>
         </div>
 
         {queue.length === 0 ? (

--- a/src/app/[locale]/offline-demo/OfflineDemo.tsx
+++ b/src/app/[locale]/offline-demo/OfflineDemo.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { ButtonLink } from "@/entities/Router";
+import { PAGE_ROUTE } from "@/entities/Router/configs/route";
+
+const STORAGE_KEY = "offline-demo-outbox";
+
+type OutboxItem = {
+  id: string;
+  content: string;
+  createdAt: number;
+  status: "queued" | "sending" | "sent" | "failed";
+  error?: string;
+};
+
+const safeParseQueue = (): OutboxItem[] => {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+
+  if (!raw) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as OutboxItem[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    console.error("Failed to parse outbox", error);
+    return [];
+  }
+};
+
+const persistQueue = (queue: OutboxItem[]) => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(queue));
+};
+
+const createItem = (content: string): OutboxItem => ({
+  id: crypto.randomUUID?.() ?? `outbox-${Date.now()}`,
+  content,
+  createdAt: Date.now(),
+  status: "queued",
+});
+
+const OfflineDemo = () => {
+  const [message, setMessage] = useState("");
+  const [queue, setQueue] = useState<OutboxItem[]>([]);
+  const [isOnline, setIsOnline] = useState(true);
+  const [isFlushing, setIsFlushing] = useState(false);
+
+  useEffect(() => {
+    setIsOnline(navigator.onLine);
+    setQueue(safeParseQueue());
+
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, []);
+
+  useEffect(() => {
+    persistQueue(queue);
+  }, [queue]);
+
+  useEffect(() => {
+    if (isOnline && queue.some((item) => item.status === "queued" || item.status === "failed")) {
+      void flushQueue();
+    }
+  }, [isOnline]);
+
+  const hasPending = useMemo(() => queue.some((item) => item.status === "queued" || item.status === "failed"), [queue]);
+
+  const addMessage = () => {
+    const trimmed = message.trim();
+
+    if (!trimmed) {
+      return;
+    }
+
+    setQueue((prev) => [...prev, createItem(trimmed)]);
+    setMessage("");
+  };
+
+  const updateStatus = (id: string, status: OutboxItem["status"], error?: string) => {
+    setQueue((prev) =>
+      prev.map((item) =>
+        item.id === id
+          ? {
+              ...item,
+              status,
+              error,
+            }
+          : item,
+      ),
+    );
+  };
+
+  const flushQueue = async () => {
+    if (isFlushing) {
+      return;
+    }
+
+    setIsFlushing(true);
+
+    for (const item of queue) {
+      if (item.status === "sent") {
+        continue;
+      }
+
+      updateStatus(item.id, "sending");
+
+      try {
+        const response = await fetch("/api/offline-demo", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            id: item.id,
+            message: item.content,
+            createdAt: item.createdAt,
+          }),
+        });
+
+        if (!response.ok) {
+          throw new Error(`API returned ${response.status}`);
+        }
+
+        updateStatus(item.id, "sent");
+      } catch (error) {
+        console.error("Failed to flush", error);
+        updateStatus(item.id, "failed", error instanceof Error ? error.message : "Unknown error");
+      }
+    }
+
+    setIsFlushing(false);
+  };
+
+  return (
+    <div className="flex min-h-screen w-full flex-col items-center bg-background-01 px-4 py-12 text-text-01">
+      <div className="mb-6 flex w-full max-w-3xl flex-col gap-3 rounded-xl border border-border-02 bg-background-op-02 p-6 shadow-md">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <p className="caption-1 text-text-03">Network</p>
+            <p className="body-1 font-semibold">{isOnline ? "온라인" : "오프라인"}</p>
+          </div>
+
+          <ButtonLink variant="primaryLine" href={PAGE_ROUTE.MAIN}>
+            홈으로
+          </ButtonLink>
+        </div>
+
+        <p className="body-2 text-text-02">
+          입력한 메시지는 Outbox (로컬 영속 큐)에 저장됩니다. 오프라인이어도 큐에 기록되며, 온라인 상태가 되면 자동으로 Next API
+          route로 전송되어 서버 콘솔에 기록됩니다.
+        </p>
+      </div>
+
+      <div className="mb-4 flex w-full max-w-3xl flex-col gap-3 rounded-xl border border-border-02 bg-background-op-02 p-6 shadow-md">
+        <label className="caption-1 text-text-03" htmlFor="message">
+          메시지 작성
+        </label>
+        <textarea
+          id="message"
+          value={message}
+          onChange={(event) => setMessage(event.target.value)}
+          className="min-h-[120px] w-full rounded-lg border border-border-02 bg-background-02 p-3 outline-none focus:border-text-01"
+          placeholder="오프라인 상태에서도 저장됩니다"
+        />
+        <div className="flex items-center justify-end gap-3">
+          <button
+            type="button"
+            onClick={addMessage}
+            className="rounded-lg bg-text-01 px-4 py-2 text-background-01 transition hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-40"
+            disabled={!message.trim()}
+          >
+            Outbox에 추가
+          </button>
+          <button
+            type="button"
+            onClick={() => void flushQueue()}
+            className="rounded-lg border border-text-01 px-4 py-2 text-text-01 transition hover:bg-text-01 hover:text-background-01 disabled:cursor-not-allowed disabled:opacity-40"
+            disabled={!hasPending || isFlushing}
+          >
+            {isFlushing ? "전송 중" : "바로 전송"}
+          </button>
+        </div>
+      </div>
+
+      <div className="flex w-full max-w-3xl flex-col gap-3 rounded-xl border border-border-02 bg-background-op-02 p-6 shadow-md">
+        <div className="flex items-center justify-between">
+          <p className="body-1 font-semibold">Outbox</p>
+          <p className="caption-1 text-text-03">자동 저장 및 재전송</p>
+        </div>
+
+        {queue.length === 0 ? (
+          <p className="body-2 text-text-03">저장된 메시지가 없습니다.</p>
+        ) : (
+          <ul className="flex flex-col gap-3">
+            {queue
+              .toSorted((a, b) => b.createdAt - a.createdAt)
+              .map((item) => (
+                <li key={item.id} className="flex flex-col gap-1 rounded-lg border border-border-02 bg-background-01 p-4">
+                  <div className="flex items-center justify-between">
+                    <span className="caption-1 text-text-03">
+                      {new Date(item.createdAt).toLocaleString()} • {item.id}
+                    </span>
+                    <span
+                      className={`body-3 rounded-full px-2 py-1 text-xs font-semibold ${
+                        item.status === "sent"
+                          ? "bg-green-100 text-green-800"
+                          : item.status === "sending"
+                            ? "bg-blue-100 text-blue-800"
+                            : item.status === "failed"
+                              ? "bg-red-100 text-red-800"
+                              : "bg-yellow-100 text-yellow-800"
+                      }`}
+                    >
+                      {item.status}
+                    </span>
+                  </div>
+                  <p className="body-2 whitespace-pre-wrap text-text-02">{item.content}</p>
+                  {item.error ? <p className="caption-1 text-red-500">{item.error}</p> : null}
+                </li>
+              ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default OfflineDemo;

--- a/src/app/[locale]/offline-demo/outboxStorage.ts
+++ b/src/app/[locale]/offline-demo/outboxStorage.ts
@@ -1,0 +1,89 @@
+export type OutboxItem = {
+  id: string;
+  content: string;
+  createdAt: number;
+  status: "queued" | "sending" | "sent" | "failed";
+  error?: string;
+};
+
+const DB_NAME = "offline-demo-db";
+const STORE_NAME = "outbox";
+const DB_VERSION = 1;
+
+const openDatabase = (): Promise<IDBDatabase> =>
+  new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: "id" });
+      }
+    };
+
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+
+const runTransaction = async <T>(mode: IDBTransactionMode, fn: (store: IDBObjectStore) => IDBRequest<T>) => {
+  const db = await openDatabase();
+  return new Promise<T>((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, mode);
+    const store = transaction.objectStore(STORE_NAME);
+    const request = fn(store);
+
+    request.onsuccess = () => resolve(request.result as T);
+    request.onerror = () => reject(request.error);
+  });
+};
+
+export const getAllOutboxItems = async (): Promise<OutboxItem[]> => {
+  const db = await openDatabase();
+  return new Promise<OutboxItem[]>((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, "readonly");
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.getAll();
+
+    request.onsuccess = () => resolve((request.result ?? []) as OutboxItem[]);
+    request.onerror = () => reject(request.error);
+  });
+};
+
+export const putOutboxItem = async (item: OutboxItem) =>
+  runTransaction("readwrite", (store) => store.put(item));
+
+export const bulkPutOutboxItems = async (items: OutboxItem[]) => {
+  const db = await openDatabase();
+  await new Promise<void>((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, "readwrite");
+    const store = transaction.objectStore(STORE_NAME);
+
+    items.forEach((item) => store.put(item));
+
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error);
+  });
+};
+
+export const updateOutboxStatus = async (id: string, status: OutboxItem["status"], error?: string) => {
+  const db = await openDatabase();
+  await new Promise<void>((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, "readwrite");
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.get(id);
+
+    request.onsuccess = () => {
+      const existing = request.result as OutboxItem | undefined;
+      if (!existing) {
+        resolve();
+        return;
+      }
+
+      store.put({ ...existing, status, error });
+      transaction.oncomplete = () => resolve();
+    };
+
+    request.onerror = () => reject(request.error);
+    transaction.onerror = () => reject(transaction.error);
+  });
+};

--- a/src/app/[locale]/offline-demo/page.tsx
+++ b/src/app/[locale]/offline-demo/page.tsx
@@ -1,0 +1,11 @@
+import { setRequestLocale } from "next-intl/server";
+
+import OfflineDemo from "./OfflineDemo";
+
+const OfflineDemoPage = ({ params }: { params: { locale: string } }) => {
+  setRequestLocale(params.locale);
+
+  return <OfflineDemo />;
+};
+
+export default OfflineDemoPage;

--- a/src/app/api/offline-demo/route.ts
+++ b/src/app/api/offline-demo/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request) {
+  const body = (await request.json()) as { id?: string; message?: string; createdAt?: number };
+
+  console.log("Offline demo API received", body);
+
+  return NextResponse.json({
+    ok: true,
+    receivedAt: new Date().toISOString(),
+    echo: body,
+  });
+}


### PR DESCRIPTION
## Summary
- add an offline-first demo page under the locale namespace that queues messages in an outbox and flushes when online
- persist queued messages locally and allow manual or automatic flushing to demonstrate offline intent preservation
- expose a simple API route that accepts queued payloads and logs them on the server

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e6d95c4bc832ebf96fe0b53d95fa3)