### PR TITLE
Center cookie banner text on mobile

### DIFF
--- a/src/shared/libs/CookieConsent/ui/CookieConsentBanner.tsx
+++ b/src/shared/libs/CookieConsent/ui/CookieConsentBanner.tsx
@@ -24,8 +24,8 @@ export function CookieConsentBanner({ onAcceptAll, onRejectAll, onCustomize }: C
       aria-live="polite"
     >
       <div className="max-w-4xl mx-auto">
-        <div className="flex flex-col sm:flex-row items-start sm:items-center gap-4">
-          <div className="flex-1">
+        <div className="flex flex-col sm:flex-row items-center gap-4">
+          <div className="w-full flex-1 text-center sm:w-auto sm:text-left">
             <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">{t("banner.title")}</h3>
             <p className="text-sm text-gray-600 dark:text-gray-300 mb-4">{t("banner.description")}</p>
           </div>


### PR DESCRIPTION
### Motivation
- Ensure the cookie consent banner copy is horizontally centered on narrow (mobile) viewports to prevent a left-aligned appearance while preserving the existing layout on `sm+` screens.

### Description
- Update `src/shared/libs/CookieConsent/ui/CookieConsentBanner.tsx` to use `items-center` on the banner row and change the text container to `w-full flex-1 text-center sm:w-auto sm:text-left` so content is centered on mobile and left-aligned on larger screens.

### Testing
- Ran `yarn eslint src/shared/libs/CookieConsent/ui/CookieConsentBanner.tsx` which completed without errors (warnings present). 
- Ran `git diff --check -- src/shared/libs/CookieConsent/ui/CookieConsentBanner.tsx` which reported no issues. 
- Commit completed successfully via the pre-commit hook which produced 27 lint warnings but no blocking errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a256a5b033c8329ac8390950bfc67a3)